### PR TITLE
Use redhat.registry for 3scale gateway name

### DIFF
--- a/apicast-gateway/apicast-gateway-template.yml
+++ b/apicast-gateway/apicast-gateway-template.yml
@@ -113,7 +113,7 @@ parameters:
   name: THREESCALE_GATEWAY_NAME
   required: true
 - description: "Docker image to use."
-  value: 'rhamp10/apicast-gateway:1.0.0-4'
+  value: 'registry.access.redhat.com/rhamp10/apicast-gateway:1.0.0-4'
   name: THREESCALE_GATEWAY_IMAGE
   required: true
 - description: "DNS Resolver for openresty, if empty it will be autodiscovered"


### PR DESCRIPTION
updated 3scale gateway image name to use registry.access.redhat.com