### PR TITLE
Fix repo locations for redis, memcached and mysql

### DIFF
--- a/amp/amp-s3.yml
+++ b/amp/amp-s3.yml
@@ -719,7 +719,7 @@ objects:
         containers:
         - args:
           env:
-          image: 3scale-amp20/memcached:1.4.15-8
+          image: registry.access.redhat.com/3scale-amp20/memcached:1.4.15-8
           imagePullPolicy: Always
           name: memcache
           readinessProbe:
@@ -1789,11 +1789,11 @@ parameters:
 - name: REDIS_IMAGE
   description: Redis image to use
   required: true
-  value: "rhscl/redis-32-rhel7:3.2"
+  value: "registry.access.redhat.com/rhscl/redis-32-rhel7"
 - name: MYSQL_IMAGE
   description: Mysql image to use
   required: true
-  value: "rhscl/mysql-56-rhel7:5.6"
+  value: "registry.access.redhat.com/rhscl/mysql-56-rhel7"
 - name: SYSTEM_BACKEND_SHARED_SECRET
   description: Shared secret to import events from backend to system.
   generate: expression

--- a/amp/amp.yml
+++ b/amp/amp.yml
@@ -715,7 +715,7 @@ objects:
         containers:
         - args:
           env:
-          image: 3scale-amp20/memcached:1.4.15-8
+          image: registry.access.redhat.com/3scale-amp20/memcached:1.4.15-8
           imagePullPolicy: Always
           name: memcache
           readinessProbe:
@@ -1795,11 +1795,11 @@ parameters:
 - name: REDIS_IMAGE
   description: Redis image to use
   required: true
-  value: "rhscl/redis-32-rhel7:3.2"
+  value: "registry.access.redhat.com/rhscl/redis-32-rhel7"
 - name: MYSQL_IMAGE
   description: Mysql image to use
   required: true
-  value: "rhscl/mysql-56-rhel7:5.6"
+  value: "registry.access.redhat.com/rhscl/mysql-56-rhel7"
 - name: SYSTEM_BACKEND_SHARED_SECRET
   description: Shared secret to import events from backend to system.
   generate: expression


### PR DESCRIPTION
If registry.access.redhat.com is not inside repo list, the deployment procedure is not completely finished.
This fix image locations to the common place - registry.access.redhat.com that are defined for other images