### PR TITLE
Fix memcached image location to registry.access.redhat.com

### DIFF
--- a/amp/amp-s3.yml
+++ b/amp/amp-s3.yml
@@ -828,7 +828,7 @@ objects:
         containers:
         - args:
           env:
-          image: 3scale-amp20/memcached:1.4.15-8
+          image: registry.access.redhat.com/3scale-amp20/memcached:1.4.15-8
           imagePullPolicy: IfNotPresent
           name: memcache
           resources:

--- a/amp/amp.yml
+++ b/amp/amp.yml
@@ -812,7 +812,7 @@ objects:
         containers:
         - args:
           env:
-          image: 3scale-amp20/memcached:1.4.15-8
+          image: registry.access.redhat.com/3scale-amp20/memcached:1.4.15-8
           imagePullPolicy: IfNotPresent
           name: memcache
           resources:


### PR DESCRIPTION
According to my PR (https://github.com/3scale/3scale-amp-openshift-templates/pull/16) the location of redis and mysql were fixed, but memcached was missing.