### PR TITLE
Adding Namespace indication on the imagestream

### DIFF
--- a/apicast-gateway/library/apicast.yml
+++ b/apicast-gateway/library/apicast.yml
@@ -101,6 +101,7 @@ objects:
         from:
           kind: ImageStreamTag
           name: apicast-gateway:latest
+          namespace: openshift
 
 - apiVersion: v1
   kind: Service


### PR DESCRIPTION
So the Imagestream can be found on the openshift namespace where the library is deployed.

Raised in https://bugzilla.redhat.com/show_bug.cgi?id=1591615