### PR TITLE
Creating the Secret inside of the APIcast template

### DIFF
--- a/apicast-gateway/library/apicast.yml
+++ b/apicast-gateway/library/apicast.yml
@@ -34,7 +34,7 @@ objects:
           - name: THREESCALE_PORTAL_ENDPOINT
             valueFrom:
               secretKeyRef:
-                name: "${CONFIGURATION_URL_SECRET}"
+                name: "apicast-configuration-url-secret"
                 key: password
           - name: THREESCALE_CONFIG_FILE
             value: "${CONFIGURATION_FILE_PATH}"
@@ -120,10 +120,22 @@ objects:
     selector:
       deploymentconfig: "${APICAST_NAME}"
 
+- kind: Secret
+  apiVersion: v1
+  stringData:
+    password: "https://${ACCESS_TOKEN}@${DOMAIN}-admin.3scale.net"
+  metadata:
+    name: apicast-configuration-url-secret
+  type: Opaque
+
 parameters:
-- description: "Name of the secret containing the THREESCALE_PORTAL_ENDPOINT with the access-token or provider key"
-  value: apicast-configuration-url-secret
-  name: CONFIGURATION_URL_SECRET
+- description: "Access Token (not a Service Token) for the 3scale Account Management API"
+  value:
+  name: ACCESS_TOKEN
+  required: true
+- description: "The domain found on the URL of your 3scale Admin Portal: https://<domain>-admin.3scale.net"
+  value:
+  name: DOMAIN
   required: true
 - description: "Path to saved JSON file with configuration for the gateway. Has to be injected to the docker image as read only volume."
   value:


### PR DESCRIPTION
Creating the `apicast-configuration-url-secret`from within the APIcast template. Corrects this problem: https://bugzilla.redhat.com/show_bug.cgi?id=1592518