### PR TITLE
[THREESCALE-925] Changing CONFIGURATION_URL_SECRET description value

### DIFF
--- a/apicast-gateway/apicast.yml
+++ b/apicast-gateway/apicast.yml
@@ -116,7 +116,7 @@ parameters:
   value: apicast-configuration-url-secret
   name: CONFIGURATION_URL_SECRET
   required: true
-- description: "Path to saved JSON file with configuration for the gateway. Has to be injected to the docker image as read only volume."
+- description: "Path to saved JSON file with configuration for the gateway. Has to be injected to the container image as read only volume."
   value:
   name: CONFIGURATION_FILE_PATH
   required: false


### PR DESCRIPTION
Changing CONFIGURATION_URL_SECRET description value to use the text 'container' instead of 'docker'.