### PR TITLE
amp template review

### DIFF
--- a/amp/amp-ephemeral.yml
+++ b/amp/amp-ephemeral.yml
@@ -206,65 +206,6 @@ objects:
         name: registry.access.redhat.com/3scale-amp22/wildcard-router:1.6
 
 - apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    name: system-storage
-    labels:
-      application: 3scale-amp
-      service: system
-      system: app
-  spec:
-    accessModes:
-      - ReadWriteMany
-    resources:
-      requests:
-        storage: 100Mi
-
-- apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    name: mysql-storage
-    labels:
-      application: 3scale-amp
-      service: system
-      system: mysql
-  spec:
-    accessModes:
-      - ReadWriteOnce
-    resources:
-      requests:
-        storage: 1Gi
-
-- apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    name: system-redis-storage
-    labels:
-      application: 3scale-amp
-      service: system
-      system: redis
-  spec:
-    accessModes:
-      - ReadWriteOnce
-    resources:
-      requests:
-        storage: 1Gi
-
-- apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    name: backend-redis-storage
-    labels:
-      application: 3scale-amp
-      service: backend
-      backend: redis
-  spec:
-    accessModes:
-      - ReadWriteOnce
-    resources:
-      requests:
-        storage: 1Gi
-- apiVersion: v1
   kind: DeploymentConfig
   metadata:
     name: backend-cron
@@ -400,8 +341,7 @@ objects:
             mountPath: /etc/redis.d/
         volumes:
         - name: backend-redis-storage
-          persistentVolumeClaim:
-            claimName: backend-redis-storage
+          emptyDir: {}
         - name: redis-config
           configMap:
             name: redis-config
@@ -767,8 +707,7 @@ objects:
             periodSeconds: 5
         volumes:
         - name: system-redis-storage
-          persistentVolumeClaim:
-            claimName: system-redis-storage
+          emptyDir: {}
         - name: redis-config
           configMap:
             name: redis-config
@@ -828,8 +767,8 @@ objects:
           emptyDir: {}
         initContainers:
         - name: zync-svc
-          image: busybox:latest
-          command: ['sh', '-c', 'until $(curl --output /dev/null --silent --head --fail http://zync:8080/status/ready); do sleep $SLEEP_SECONDS; done']
+          image: busybox
+          command: ['sh', '-c', 'until $(wget -qO /dev/null http://zync:8080/status/ready); do sleep $SLEEP_SECONDS; done']
           activeDeadlineSeconds: 600
           env:
           - name: SLEEP_SECONDS
@@ -1644,8 +1583,7 @@ objects:
             mountPath: /opt/system-extra-configs
         volumes:
         - name: system-storage
-          persistentVolumeClaim:
-            claimName: system-storage
+          emptyDir: {}
         - name: system-config
           configMap:
             name: system
@@ -1731,8 +1669,7 @@ objects:
               memory: 200Mi
         volumes:
         - name: system-storage
-          persistentVolumeClaim:
-            claimName: system-storage
+          emptyDir: {}
     triggers:
       - type: ConfigChange
       - type: ImageChange
@@ -1800,8 +1737,7 @@ objects:
           emptyDir:
             medium: Memory
         - name: system-storage
-          persistentVolumeClaim:
-            claimName: system-storage
+          emptyDir: {}
         - name: system-config
           configMap:
             name: system
@@ -1897,8 +1833,7 @@ objects:
             imagePullPolicy: IfNotPresent
         volumes:
           - name: mysql-storage
-            persistentVolumeClaim:
-              claimName: mysql-storage
+            emptyDir: {}
           - name: mysql-extra-conf
             configMap:
               name: mysql-extra-conf
@@ -1989,7 +1924,7 @@ objects:
       system: postgresql
   spec:
     tags:
-      - name: 9.5
+      - name: '9.5'
         from:
           kind: DockerImage
           name: registry.access.redhat.com/rhscl/postgresql-95-rhel7:9.5

--- a/amp/amp-ephemeral.yml
+++ b/amp/amp-ephemeral.yml
@@ -235,8 +235,8 @@ objects:
       spec:
         initContainers:
         - name: backend-redis-svc
-          image: busybox
-          command: ['sh', '-c', 'until $(nc -z backend-redis 6379); do sleep $SLEEP_SECONDS; done']
+          image: registry.access.redhat.com/rhel-atomic:7.5
+          command: ['sh', '-c', 'until $(echo -n > /dev/tcp/backend-redis/6379); do sleep $SLEEP_SECONDS; done']
           activeDeadlineSeconds: 600
           env:
           - name: SLEEP_SECONDS
@@ -560,8 +560,8 @@ objects:
       spec:
         initContainers:
         - name: backend-redis-svc
-          image: busybox
-          command: ['sh', '-c', 'until $(nc -z backend-redis 6379); do sleep $SLEEP_SECONDS; done']
+          image: registry.access.redhat.com/rhel-atomic:7.5
+          command: ['sh', '-c', 'until $(echo -n > /dev/tcp/backend-redis/6379); do sleep $SLEEP_SECONDS; done']
           activeDeadlineSeconds: 600
           env:
           - name: SLEEP_SECONDS
@@ -767,8 +767,8 @@ objects:
           emptyDir: {}
         initContainers:
         - name: zync-svc
-          image: busybox
-          command: ['sh', '-c', 'until $(wget -qO /dev/null http://zync:8080/status/ready); do sleep $SLEEP_SECONDS; done']
+          image: registry.access.redhat.com/rhel-atomic:7.5
+          command: ['sh', '-c', 'until $(curl --output /dev/null --silent --head --fail http://zync:8080/status/ready); do sleep $SLEEP_SECONDS; done']
           activeDeadlineSeconds: 600
           env:
           - name: SLEEP_SECONDS
@@ -1175,8 +1175,8 @@ objects:
       spec:
         initContainers:
         - name: system-master-svc
-          image: busybox
-          command: ['sh', '-c', 'until $(nc -z system-master 3000); do sleep $SLEEP_SECONDS; done']
+          image: registry.access.redhat.com/rhel-atomic:7.5
+          command: ['sh', '-c', 'until $(echo -n > /dev/tcp/system-master/3000); do sleep $SLEEP_SECONDS; done']
           activeDeadlineSeconds: 600
           env:
           - name: SLEEP_SECONDS
@@ -1924,10 +1924,10 @@ objects:
       system: postgresql
   spec:
     tags:
-      - name: '9.5'
-        from:
-          kind: DockerImage
-          name: registry.access.redhat.com/rhscl/postgresql-95-rhel7:9.5
+    - name: "9.5"
+      from:
+        kind: DockerImage
+        name: registry.access.redhat.com/rhscl/postgresql-95-rhel7:9.5
 
 - kind: ImageStream
   apiVersion: v1

--- a/amp/amp.yml
+++ b/amp/amp.yml
@@ -294,8 +294,8 @@ objects:
       spec:
         initContainers:
         - name: backend-redis-svc
-          image: busybox
-          command: ['sh', '-c', 'until $(nc -z backend-redis 6379); do sleep $SLEEP_SECONDS; done']
+          image: registry.access.redhat.com/rhel-atomic:7.5
+          command: ['sh', '-c', 'until $(echo -n > /dev/tcp/backend-redis/6379); do sleep $SLEEP_SECONDS; done']
           activeDeadlineSeconds: 600
           env:
           - name: SLEEP_SECONDS
@@ -620,8 +620,8 @@ objects:
       spec:
         initContainers:
         - name: backend-redis-svc
-          image: busybox
-          command: ['sh', '-c', 'until $(nc -z backend-redis 6379); do sleep $SLEEP_SECONDS; done']
+          image: registry.access.redhat.com/rhel-atomic:7.5
+          command: ['sh', '-c', 'until $(echo -n > /dev/tcp/backend-redis/6379); do sleep $SLEEP_SECONDS; done']
           activeDeadlineSeconds: 600
           env:
           - name: SLEEP_SECONDS
@@ -828,7 +828,7 @@ objects:
           emptyDir: {}
         initContainers:
         - name: zync-svc
-          image: busybox:latest
+          image: registry.access.redhat.com/rhel-atomic:7.5
           command: ['sh', '-c', 'until $(curl --output /dev/null --silent --head --fail http://zync:8080/status/ready); do sleep $SLEEP_SECONDS; done']
           activeDeadlineSeconds: 600
           env:
@@ -1236,8 +1236,8 @@ objects:
       spec:
         initContainers:
         - name: system-master-svc
-          image: busybox
-          command: ['sh', '-c', 'until $(nc -z system-master 3000); do sleep $SLEEP_SECONDS; done']
+          image: registry.access.redhat.com/rhel-atomic:7.5
+          command: ['sh', '-c', 'until $(echo -n > /dev/tcp/system-master/3000); do sleep $SLEEP_SECONDS; done']
           activeDeadlineSeconds: 600
           env:
           - name: SLEEP_SECONDS
@@ -1989,10 +1989,10 @@ objects:
       system: postgresql
   spec:
     tags:
-      - name: 9.5
-        from:
-          kind: DockerImage
-          name: registry.access.redhat.com/rhscl/postgresql-95-rhel7:9.5
+    - name: "9.5"
+      from:
+        kind: DockerImage
+        name: registry.access.redhat.com/rhscl/postgresql-95-rhel7:9.5
 
 - kind: ImageStream
   apiVersion: v1


### PR DESCRIPTION
I checked the existing amp template and performed the following changes:

* Added label `application=3scale-amp` to all components
* Added label `service=[backend,system,apicast]` to be able to group subsets of components
* Added label `[backend,system,apicast]=[redis,wildcar-router,mysql,...]` for the different components of such groups
* Use `deploymentConfig: <name>` for selector
* removed deprecated annotation `service.alpha.openshift.io/dependencies`
* Added ephemeral template (for testing)
* Adapted probes to less powerful environments
* Added initContainers to wait until dependencies are ready

Signed-off-by: Ruben Romero Montes <rromerom@redhat.com>