### PR TITLE
added parameter to set image registry url

### DIFF
--- a/amp/amp.yml
+++ b/amp/amp.yml
@@ -129,7 +129,7 @@ objects:
         openshift.io/display-name: AMP system ${AMP_RELEASE}
       from:
         kind: DockerImage
-        name: registry.access.redhat.com/3scale-amp22/system:1.7
+        name: ${IMAGE_REGISTRY_URL}/3scale-amp22/system:1.7
 - kind: ImageStream
   apiVersion: v1
   metadata:
@@ -149,7 +149,7 @@ objects:
         openshift.io/display-name: amp-backend ${AMP_RELEASE}
       from:
         kind: DockerImage
-        name: registry.access.redhat.com/3scale-amp22/backend:1.6
+        name: ${IMAGE_REGISTRY_URL}/3scale-amp22/backend:1.6
 - kind: ImageStream
   apiVersion: v1
   metadata:
@@ -169,7 +169,7 @@ objects:
         openshift.io/display-name: AMP APIcast ${AMP_RELEASE}
       from:
         kind: DockerImage
-        name: registry.access.redhat.com/3scale-amp22/apicast-gateway:1.8
+        name: ${IMAGE_REGISTRY_URL}/3scale-amp22/apicast-gateway:1.8
 - kind: ImageStream
   apiVersion: v1
   metadata:
@@ -189,7 +189,7 @@ objects:
         openshift.io/display-name: AMP APIcast Wildcard Router ${AMP_RELEASE}
       from:
         kind: DockerImage
-        name: registry.access.redhat.com/3scale-amp22/wildcard-router:1.6
+        name: ${IMAGE_REGISTRY_URL}/3scale-amp22/wildcard-router:1.6
 
 - apiVersion: "v1"
   kind: "PersistentVolumeClaim"
@@ -812,7 +812,7 @@ objects:
         containers:
         - args:
           env:
-          image: registry.access.redhat.com/3scale-amp20/memcached:1.4.15
+          image: ${IMAGE_REGISTRY_URL}/3scale-amp20/memcached:1.4.15
           imagePullPolicy: IfNotPresent
           name: memcache
           resources:
@@ -1770,7 +1770,7 @@ objects:
       - name: '9.5'
         from:
           kind: DockerImage
-          name: registry.access.redhat.com/rhscl/postgresql-95-rhel7:9.5
+          name: ${IMAGE_REGISTRY_URL}/rhscl/postgresql-95-rhel7:9.5
 
 - kind: ImageStream
   apiVersion: v1
@@ -1791,7 +1791,7 @@ objects:
         openshift.io/display-name: AMP Zync ${AMP_RELEASE}
       from:
         kind: DockerImage
-        name: registry.access.redhat.com/3scale-amp22/zync:1.6
+        name: ${IMAGE_REGISTRY_URL}/3scale-amp22/zync:1.6
 - kind: Secret
   apiVersion: v1
   stringData:
@@ -2077,11 +2077,11 @@ parameters:
 - name: REDIS_IMAGE
   description: Redis image to use
   required: true
-  value: "registry.access.redhat.com/rhscl/redis-32-rhel7:3.2"
+  value: "${IMAGE_REGISTRY_URL}/rhscl/redis-32-rhel7:3.2"
 - name: MYSQL_IMAGE
   description: Mysql image to use
   required: true
-  value: "registry.access.redhat.com/rhscl/mysql-57-rhel7:5.7-5"
+  value: "${IMAGE_REGISTRY_URL}/rhscl/mysql-57-rhel7:5.7-5"
 - name: SYSTEM_BACKEND_SHARED_SECRET
   description: Shared secret to import events from backend to system.
   generate: expression
@@ -2122,4 +2122,8 @@ parameters:
 - name: APICAST_REGISTRY_URL
   description: "The URL to point to APIcast policies registry management"
   value: "http://apicast-staging:8090/policies"
+  required: true
+- name: IMAGE_REGISTRY_URL
+  description: "The URL to point to image registry"
+  value: registry.access.redhat.com
   required: true


### PR DESCRIPTION
Some of our customers have disconnected openshift installations where the nodes in the openshift cluster cannot directly access registry.access.redhat.com. In these cases we usually deploy an internal registry that the custers can use to pull images.

I have added a parameter to the amp deployment template to allow easy deployment of 3scale AMP to a disconnected openshift cluster. The parameter can be used to change the registry hostname to an internal registry host.