### PR TITLE
Revert "update imagestreams to registry.redhat.io"

### DIFF
--- a/3scale-image-streams.yml
+++ b/3scale-image-streams.yml
@@ -24,8 +24,6 @@ items:
           will automatically update to use the latest version of 3Scale APIcast API Gateway
           available on OpenShift, including major versions updates.
         tags: api,gateway,3scale
-      referencePolicy:
-        type: Local
       from:
         kind: ImageStreamTag
         name: 2.2.0.GA
@@ -41,11 +39,9 @@ items:
           with external Identity Providers such as Red Hat Single Sign On, for API traffic authentication.
         tags: api,gateway,3scale
         version: 2.1.0.GA
-      referencePolicy:
-        type: Local
       from:
         kind: DockerImage
-        name: registry.redhat.io/3scale-amp21/apicast-gateway:1.4-2
+        name: registry.access.redhat.com/3scale-amp21/apicast-gateway:1.4-2
 
     - name: 2.2.0.GA
       annotations:
@@ -58,8 +54,6 @@ items:
           with external Identity Providers such as Red Hat Single Sign On, for API traffic authentication.
         tags: api,gateway,3scale
         version: 2.2.0.GA
-      referencePolicy:
-        type: Local
       from:
         kind: DockerImage
-        name: registry.redhat.io/3scale-amp22/apicast-gateway:1.8
+        name: registry.access.redhat.com/3scale-amp22/apicast-gateway:1.8


### PR DESCRIPTION
Reverts 3scale/3scale-amp-openshift-templates#29

The new registry requires authentication. The new registry will be used when the templates are adapted to use authentication, credentials are created for it and documentation is updated.