### PR TITLE
Updating backend redis connectivity test to include sentinel variables

### DIFF
--- a/amp/amp-eval-tech-preview.yml
+++ b/amp/amp-eval-tech-preview.yml
@@ -571,6 +571,16 @@ objects:
               secretKeyRef:
                 key: REDIS_QUEUES_URL
                 name: backend-redis
+          - name: CONFIG_QUEUES_SENTINEL_HOSTS
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_QUEUES_SENTINEL_HOSTS
+                name: backend-redis
+          - name: CONFIG_QUEUES_SENTINEL_ROLE
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_QUEUES_SENTINEL_ROLE
+                name: backend-redis
           image: amp-backend:latest
           name: backend-redis-svc
           resources: {}
@@ -857,6 +867,16 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: REDIS_QUEUES_URL
+                name: backend-redis
+          - name: CONFIG_QUEUES_SENTINEL_HOSTS
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_QUEUES_SENTINEL_HOSTS
+                name: backend-redis
+          - name: CONFIG_QUEUES_SENTINEL_ROLE
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_QUEUES_SENTINEL_ROLE
                 name: backend-redis
           image: amp-backend:latest
           name: backend-redis-svc

--- a/amp/amp-ha-tech-preview.yml
+++ b/amp/amp-ha-tech-preview.yml
@@ -316,6 +316,16 @@ objects:
               secretKeyRef:
                 key: REDIS_QUEUES_URL
                 name: backend-redis
+          - name: CONFIG_QUEUES_SENTINEL_HOSTS
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_QUEUES_SENTINEL_HOSTS
+                name: backend-redis
+          - name: CONFIG_QUEUES_SENTINEL_ROLE
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_QUEUES_SENTINEL_ROLE
+                name: backend-redis
           image: amp-backend:latest
           name: backend-redis-svc
           resources: {}
@@ -614,6 +624,16 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: REDIS_QUEUES_URL
+                name: backend-redis
+          - name: CONFIG_QUEUES_SENTINEL_HOSTS
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_QUEUES_SENTINEL_HOSTS
+                name: backend-redis
+          - name: CONFIG_QUEUES_SENTINEL_ROLE
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_QUEUES_SENTINEL_ROLE
                 name: backend-redis
           image: amp-backend:latest
           name: backend-redis-svc

--- a/amp/amp-s3.yml
+++ b/amp/amp-s3.yml
@@ -590,6 +590,16 @@ objects:
               secretKeyRef:
                 key: REDIS_QUEUES_URL
                 name: backend-redis
+          - name: CONFIG_QUEUES_SENTINEL_HOSTS
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_QUEUES_SENTINEL_HOSTS
+                name: backend-redis
+          - name: CONFIG_QUEUES_SENTINEL_ROLE
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_QUEUES_SENTINEL_ROLE
+                name: backend-redis
           image: amp-backend:latest
           name: backend-redis-svc
           resources: {}
@@ -888,6 +898,16 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: REDIS_QUEUES_URL
+                name: backend-redis
+          - name: CONFIG_QUEUES_SENTINEL_HOSTS
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_QUEUES_SENTINEL_HOSTS
+                name: backend-redis
+          - name: CONFIG_QUEUES_SENTINEL_ROLE
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_QUEUES_SENTINEL_ROLE
                 name: backend-redis
           image: amp-backend:latest
           name: backend-redis-svc

--- a/amp/amp.yml
+++ b/amp/amp.yml
@@ -589,6 +589,16 @@ objects:
               secretKeyRef:
                 key: REDIS_QUEUES_URL
                 name: backend-redis
+          - name: CONFIG_QUEUES_SENTINEL_HOSTS
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_QUEUES_SENTINEL_HOSTS
+                name: backend-redis
+          - name: CONFIG_QUEUES_SENTINEL_ROLE
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_QUEUES_SENTINEL_ROLE
+                name: backend-redis
           image: amp-backend:latest
           name: backend-redis-svc
           resources: {}
@@ -887,6 +897,16 @@ objects:
             valueFrom:
               secretKeyRef:
                 key: REDIS_QUEUES_URL
+                name: backend-redis
+          - name: CONFIG_QUEUES_SENTINEL_HOSTS
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_QUEUES_SENTINEL_HOSTS
+                name: backend-redis
+          - name: CONFIG_QUEUES_SENTINEL_ROLE
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_QUEUES_SENTINEL_ROLE
                 name: backend-redis
           image: amp-backend:latest
           name: backend-redis-svc


### PR DESCRIPTION
This PR fixes the issue where `backend-cron` and `backend-worker` fail to deploy when using a redis sentinel cluster.

PR adds the following environment variables into the init container from the backend-redis secret. 
- CONFIG_QUEUES_SENTINEL_HOSTS
- CONFIG_QUEUES_SENTINEL_ROLE

Should close out [THREESCALE-2617](https://issues.jboss.org/browse/THREESCALE-2617)