### PR TITLE
Include sentinel env vars for backend init container

### DIFF
--- a/amp/amp-eval-tech-preview.yml
+++ b/amp/amp-eval-tech-preview.yml
@@ -564,13 +564,43 @@ objects:
           - until rake connectivity:redis_storage_queue_check; do sleep $SLEEP_SECONDS;
             done
           env:
-          - name: SLEEP_SECONDS
-            value: "1"
+          - name: CONFIG_REDIS_PROXY
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_STORAGE_URL
+                name: backend-redis
+          - name: CONFIG_REDIS_SENTINEL_HOSTS
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_STORAGE_SENTINEL_HOSTS
+                name: backend-redis
+          - name: CONFIG_REDIS_SENTINEL_ROLE
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_STORAGE_SENTINEL_ROLE
+                name: backend-redis
           - name: CONFIG_QUEUES_MASTER_NAME
             valueFrom:
               secretKeyRef:
                 key: REDIS_QUEUES_URL
                 name: backend-redis
+          - name: CONFIG_QUEUES_SENTINEL_HOSTS
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_QUEUES_SENTINEL_HOSTS
+                name: backend-redis
+          - name: CONFIG_QUEUES_SENTINEL_ROLE
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_QUEUES_SENTINEL_ROLE
+                name: backend-redis
+          - name: RACK_ENV
+            valueFrom:
+              configMapKeyRef:
+                key: RACK_ENV
+                name: backend-environment
+          - name: SLEEP_SECONDS
+            value: "1"
           image: amp-backend:latest
           name: backend-redis-svc
           resources: {}
@@ -851,13 +881,43 @@ objects:
           - until rake connectivity:redis_storage_queue_check; do sleep $SLEEP_SECONDS;
             done
           env:
-          - name: SLEEP_SECONDS
-            value: "1"
+          - name: CONFIG_REDIS_PROXY
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_STORAGE_URL
+                name: backend-redis
+          - name: CONFIG_REDIS_SENTINEL_HOSTS
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_STORAGE_SENTINEL_HOSTS
+                name: backend-redis
+          - name: CONFIG_REDIS_SENTINEL_ROLE
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_STORAGE_SENTINEL_ROLE
+                name: backend-redis
           - name: CONFIG_QUEUES_MASTER_NAME
             valueFrom:
               secretKeyRef:
                 key: REDIS_QUEUES_URL
                 name: backend-redis
+          - name: CONFIG_QUEUES_SENTINEL_HOSTS
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_QUEUES_SENTINEL_HOSTS
+                name: backend-redis
+          - name: CONFIG_QUEUES_SENTINEL_ROLE
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_QUEUES_SENTINEL_ROLE
+                name: backend-redis
+          - name: RACK_ENV
+            valueFrom:
+              configMapKeyRef:
+                key: RACK_ENV
+                name: backend-environment
+          - name: SLEEP_SECONDS
+            value: "1"
           image: amp-backend:latest
           name: backend-redis-svc
           resources: {}

--- a/amp/amp-ha-tech-preview.yml
+++ b/amp/amp-ha-tech-preview.yml
@@ -309,13 +309,43 @@ objects:
           - until rake connectivity:redis_storage_queue_check; do sleep $SLEEP_SECONDS;
             done
           env:
-          - name: SLEEP_SECONDS
-            value: "1"
+          - name: CONFIG_REDIS_PROXY
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_STORAGE_URL
+                name: backend-redis
+          - name: CONFIG_REDIS_SENTINEL_HOSTS
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_STORAGE_SENTINEL_HOSTS
+                name: backend-redis
+          - name: CONFIG_REDIS_SENTINEL_ROLE
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_STORAGE_SENTINEL_ROLE
+                name: backend-redis
           - name: CONFIG_QUEUES_MASTER_NAME
             valueFrom:
               secretKeyRef:
                 key: REDIS_QUEUES_URL
                 name: backend-redis
+          - name: CONFIG_QUEUES_SENTINEL_HOSTS
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_QUEUES_SENTINEL_HOSTS
+                name: backend-redis
+          - name: CONFIG_QUEUES_SENTINEL_ROLE
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_QUEUES_SENTINEL_ROLE
+                name: backend-redis
+          - name: RACK_ENV
+            valueFrom:
+              configMapKeyRef:
+                key: RACK_ENV
+                name: backend-environment
+          - name: SLEEP_SECONDS
+            value: "1"
           image: amp-backend:latest
           name: backend-redis-svc
           resources: {}
@@ -608,13 +638,43 @@ objects:
           - until rake connectivity:redis_storage_queue_check; do sleep $SLEEP_SECONDS;
             done
           env:
-          - name: SLEEP_SECONDS
-            value: "1"
+          - name: CONFIG_REDIS_PROXY
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_STORAGE_URL
+                name: backend-redis
+          - name: CONFIG_REDIS_SENTINEL_HOSTS
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_STORAGE_SENTINEL_HOSTS
+                name: backend-redis
+          - name: CONFIG_REDIS_SENTINEL_ROLE
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_STORAGE_SENTINEL_ROLE
+                name: backend-redis
           - name: CONFIG_QUEUES_MASTER_NAME
             valueFrom:
               secretKeyRef:
                 key: REDIS_QUEUES_URL
                 name: backend-redis
+          - name: CONFIG_QUEUES_SENTINEL_HOSTS
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_QUEUES_SENTINEL_HOSTS
+                name: backend-redis
+          - name: CONFIG_QUEUES_SENTINEL_ROLE
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_QUEUES_SENTINEL_ROLE
+                name: backend-redis
+          - name: RACK_ENV
+            valueFrom:
+              configMapKeyRef:
+                key: RACK_ENV
+                name: backend-environment
+          - name: SLEEP_SECONDS
+            value: "1"
           image: amp-backend:latest
           name: backend-redis-svc
           resources: {}

--- a/amp/amp-s3.yml
+++ b/amp/amp-s3.yml
@@ -583,13 +583,43 @@ objects:
           - until rake connectivity:redis_storage_queue_check; do sleep $SLEEP_SECONDS;
             done
           env:
-          - name: SLEEP_SECONDS
-            value: "1"
+          - name: CONFIG_REDIS_PROXY
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_STORAGE_URL
+                name: backend-redis
+          - name: CONFIG_REDIS_SENTINEL_HOSTS
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_STORAGE_SENTINEL_HOSTS
+                name: backend-redis
+          - name: CONFIG_REDIS_SENTINEL_ROLE
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_STORAGE_SENTINEL_ROLE
+                name: backend-redis
           - name: CONFIG_QUEUES_MASTER_NAME
             valueFrom:
               secretKeyRef:
                 key: REDIS_QUEUES_URL
                 name: backend-redis
+          - name: CONFIG_QUEUES_SENTINEL_HOSTS
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_QUEUES_SENTINEL_HOSTS
+                name: backend-redis
+          - name: CONFIG_QUEUES_SENTINEL_ROLE
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_QUEUES_SENTINEL_ROLE
+                name: backend-redis
+          - name: RACK_ENV
+            valueFrom:
+              configMapKeyRef:
+                key: RACK_ENV
+                name: backend-environment
+          - name: SLEEP_SECONDS
+            value: "1"
           image: amp-backend:latest
           name: backend-redis-svc
           resources: {}
@@ -882,13 +912,43 @@ objects:
           - until rake connectivity:redis_storage_queue_check; do sleep $SLEEP_SECONDS;
             done
           env:
-          - name: SLEEP_SECONDS
-            value: "1"
+          - name: CONFIG_REDIS_PROXY
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_STORAGE_URL
+                name: backend-redis
+          - name: CONFIG_REDIS_SENTINEL_HOSTS
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_STORAGE_SENTINEL_HOSTS
+                name: backend-redis
+          - name: CONFIG_REDIS_SENTINEL_ROLE
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_STORAGE_SENTINEL_ROLE
+                name: backend-redis
           - name: CONFIG_QUEUES_MASTER_NAME
             valueFrom:
               secretKeyRef:
                 key: REDIS_QUEUES_URL
                 name: backend-redis
+          - name: CONFIG_QUEUES_SENTINEL_HOSTS
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_QUEUES_SENTINEL_HOSTS
+                name: backend-redis
+          - name: CONFIG_QUEUES_SENTINEL_ROLE
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_QUEUES_SENTINEL_ROLE
+                name: backend-redis
+          - name: RACK_ENV
+            valueFrom:
+              configMapKeyRef:
+                key: RACK_ENV
+                name: backend-environment
+          - name: SLEEP_SECONDS
+            value: "1"
           image: amp-backend:latest
           name: backend-redis-svc
           resources: {}

--- a/amp/amp.yml
+++ b/amp/amp.yml
@@ -582,13 +582,43 @@ objects:
           - until rake connectivity:redis_storage_queue_check; do sleep $SLEEP_SECONDS;
             done
           env:
-          - name: SLEEP_SECONDS
-            value: "1"
+          - name: CONFIG_REDIS_PROXY
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_STORAGE_URL
+                name: backend-redis
+          - name: CONFIG_REDIS_SENTINEL_HOSTS
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_STORAGE_SENTINEL_HOSTS
+                name: backend-redis
+          - name: CONFIG_REDIS_SENTINEL_ROLE
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_STORAGE_SENTINEL_ROLE
+                name: backend-redis
           - name: CONFIG_QUEUES_MASTER_NAME
             valueFrom:
               secretKeyRef:
                 key: REDIS_QUEUES_URL
                 name: backend-redis
+          - name: CONFIG_QUEUES_SENTINEL_HOSTS
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_QUEUES_SENTINEL_HOSTS
+                name: backend-redis
+          - name: CONFIG_QUEUES_SENTINEL_ROLE
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_QUEUES_SENTINEL_ROLE
+                name: backend-redis
+          - name: RACK_ENV
+            valueFrom:
+              configMapKeyRef:
+                key: RACK_ENV
+                name: backend-environment
+          - name: SLEEP_SECONDS
+            value: "1"
           image: amp-backend:latest
           name: backend-redis-svc
           resources: {}
@@ -881,13 +911,43 @@ objects:
           - until rake connectivity:redis_storage_queue_check; do sleep $SLEEP_SECONDS;
             done
           env:
-          - name: SLEEP_SECONDS
-            value: "1"
+          - name: CONFIG_REDIS_PROXY
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_STORAGE_URL
+                name: backend-redis
+          - name: CONFIG_REDIS_SENTINEL_HOSTS
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_STORAGE_SENTINEL_HOSTS
+                name: backend-redis
+          - name: CONFIG_REDIS_SENTINEL_ROLE
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_STORAGE_SENTINEL_ROLE
+                name: backend-redis
           - name: CONFIG_QUEUES_MASTER_NAME
             valueFrom:
               secretKeyRef:
                 key: REDIS_QUEUES_URL
                 name: backend-redis
+          - name: CONFIG_QUEUES_SENTINEL_HOSTS
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_QUEUES_SENTINEL_HOSTS
+                name: backend-redis
+          - name: CONFIG_QUEUES_SENTINEL_ROLE
+            valueFrom:
+              secretKeyRef:
+                key: REDIS_QUEUES_SENTINEL_ROLE
+                name: backend-redis
+          - name: RACK_ENV
+            valueFrom:
+              configMapKeyRef:
+                key: RACK_ENV
+                name: backend-environment
+          - name: SLEEP_SECONDS
+            value: "1"
           image: amp-backend:latest
           name: backend-redis-svc
           resources: {}


### PR DESCRIPTION
This PR fixes the issue where backend-cron and backend-worker fail to deploy when using a redis sentinel cluster.

PR adds the following environment variables into the init container from the backend-redis secret.

    CONFIG_QUEUES_SENTINEL_HOSTS
    CONFIG_QUEUES_SENTINEL_ROLE

and also includes common envvars also used in the non-init container pod of backend-redis too

Should close out THREESCALE-2617