### PR TITLE
Fix missing oracle gem

### DIFF
--- a/amp/system-oracle/Dockerfile
+++ b/amp/system-oracle/Dockerfile
@@ -7,6 +7,9 @@ COPY ./oracle-client-files/instantclient-basic*-linux.x64-12.2.*.zip \
      ./oracle-client-files/instantclient-odbc-linux.x64-12.2.*.zip \
      /opt/oracle/
 
+COPY ./oracle-client-files/vendor/cache/activerecord-oracle_enhanced-adapter-1.6.9.gem /opt/system/vendor/cache
+COPY Gemfile.oracle /opt/system
+
 ENV LD_LIBRARY_PATH=/opt/oracle/instantclient_12_2/ \
     ORACLE_HOME=/opt/oracle/instantclient_12_2/ \
     DB=oracle \
@@ -20,7 +23,7 @@ RUN unzip /opt/oracle/instantclient-basic*-linux.x64-12.2.*.zip -d /opt/oracle/ 
  && rm -f /opt/oracle/*.zip \
  && (cd /opt/oracle/instantclient_12_2/ && ln -s libclntsh.so.12.1 libclntsh.so) \
  && source /opt/app-root/etc/scl_enable \
- && DB=oracle bundle install --local --deployment --jobs $(grep -c processor /proc/cpuinfo) --retry=5
+ && BUNDLE_GEMFILE=Gemfile.oracle DB=oracle bundle install --deployment --jobs $(grep -c processor /proc/cpuinfo) --retry=5
 
 
 USER 1001

--- a/amp/system-oracle/Dockerfile
+++ b/amp/system-oracle/Dockerfile
@@ -7,8 +7,8 @@ COPY ./oracle-client-files/instantclient-basic*-linux.x64-12.2.*.zip \
      ./oracle-client-files/instantclient-odbc-linux.x64-12.2.*.zip \
      /opt/oracle/
 
-COPY ./oracle-client-files/vendor/cache/activerecord-oracle_enhanced-adapter-1.6.9.gem /opt/system/vendor/cache
-COPY Gemfile.oracle /opt/system
+COPY ./oracle-client-files/vendor/cache/activerecord-oracle_enhanced-adapter-1.6.9.gem /opt/system/vendor/cache/
+COPY Gemfile.oracle Gemfile.oracle.lock /opt/system/
 
 ENV LD_LIBRARY_PATH=/opt/oracle/instantclient_12_2/ \
     ORACLE_HOME=/opt/oracle/instantclient_12_2/ \
@@ -21,9 +21,10 @@ RUN unzip /opt/oracle/instantclient-basic*-linux.x64-12.2.*.zip -d /opt/oracle/ 
  && unzip /opt/oracle/instantclient-sdk-linux.x64-12.2.*.zip -d /opt/oracle/ \
  && unzip /opt/oracle/instantclient-odbc-linux.x64-12.2.*.zip -d /opt/oracle/ \
  && rm -f /opt/oracle/*.zip \
- && (cd /opt/oracle/instantclient_12_2/ && ln -s libclntsh.so.12.1 libclntsh.so) \
- && source /opt/app-root/etc/scl_enable \
- && BUNDLE_GEMFILE=Gemfile.oracle DB=oracle bundle install --deployment --jobs $(grep -c processor /proc/cpuinfo) --retry=5
+ && (cd /opt/oracle/instantclient_12_2/ && ln -s libclntsh.so.12.1 libclntsh.so)
+
+RUN source /opt/app-root/etc/scl_enable \
+ && BUNDLE_GEMFILE=Gemfile.oracle DB=oracle bundle install --verbose --deployment --local
 
 
 USER 1001

--- a/amp/system-oracle/Gemfile.oracle
+++ b/amp/system-oracle/Gemfile.oracle
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'activerecord-oracle_enhanced-adapter', '~> 1.6.0'

--- a/amp/system-oracle/Gemfile.oracle.lock
+++ b/amp/system-oracle/Gemfile.oracle.lock
@@ -1,0 +1,13 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activerecord-oracle_enhanced-adapter (1.6.9)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activerecord-oracle_enhanced-adapter (~> 1.6.0)
+
+BUNDLED WITH
+   1.17.2

--- a/amp/system-oracle/README.md
+++ b/amp/system-oracle/README.md
@@ -3,6 +3,7 @@
 
 ## Prerequisites
 
+### Oracle Library Binaries
 In order to work with Oracle Database for Red Hat 3scale API Management, you will need to create a custom image as Red Hat cannot distribute the binaries of Oracle Database client.
 
 You **MUST** download the client (basic-lite or basic), the odbc driver and the sdk for **12.2** in [Oracle Technology Network](http://www.oracle.com/technetwork/database/features/instant-client/index-097480.html).
@@ -17,6 +18,14 @@ Example:
     * instantclient-sdk-linux.x64-12.2.0.1.0.zip
     * instantclient-odbc-linux.x64-12.2.0.1.0-2.zip
 
+### Oracle Gem
+
+With the binaries in place, you'll also need to fetch the open source gem:  
+
+```
+BUNDLE_GEMFILE=Gemfile.oracle bundle package --no-install --all --path .
+```
+
 ### Oracle Database user SYSTEM password
 
 We **need** the Oracle Database user `SYSTEM` password.
@@ -27,11 +36,12 @@ It will create the user and grant the appropriate roles and rights to the user c
 
 1 - Place the downloaded files in the `oracle-client-files` directory.
 
+2 - Fetch the open source gem and place it in the `oracle-client-files` directory, with: `BUNDLE_GEMFILE=Gemfile.oracle bundle package --no-install --all --path .`
 
-2 - Download the productized amp.yml template.
+3 - Download the productized amp.yml template.
 
 
-3 - Run on your machine by replacing `WILDCARD_DOMAIN`
+4 - Run on your machine by replacing `WILDCARD_DOMAIN`
 
 
 ```


### PR DESCRIPTION
This gem was _assumed_ to exist in system base image, but this is not the case any more, since the dist-git cache has been removed. 

This PR is now making this dependency explicit, and also adding it to the right place, since the gem will _only_ exist when building an image with support for oracle. 