### PR TITLE
Update System's Oracle image building method for 3scale 2.9

### DIFF
--- a/amp/system-oracle/Dockerfile
+++ b/amp/system-oracle/Dockerfile
@@ -1,4 +1,4 @@
-FROM amp-system:2.8
+FROM registry.redhat.io/3scale-amp2/system-rhel7:3scale2.9
 
 USER root
 

--- a/amp/system-oracle/README.md
+++ b/amp/system-oracle/README.md
@@ -83,6 +83,53 @@ On 3scale 2.6+, there is no need to apply any workaround patch for Non Container
 $ oc start-build 3scale-amp-system-oracle --from-dir=.
 ```
 
+8 - Wait until the build completes. The available build names can be listed by
+    executing `oc get builds` and then the state of a specific build can be
+    verified with:
+```
+$ oc get build <build-name> -o jsonpath="{.status.phase}"
+```
+
+Wait until the build is in 'Complete' state
+
+9 - Update the ImageChange triggers of the DeploymentConfigs that use the System image
+    to use the new Oracle-based System image:
+
+Save the current 3scale release in an environment variable:
+```
+$ export THREESCALE_RELEASE=2.9
+```
+
+Update system-app DeploymentConfig's ImageChangeTrigger:
+```
+$ oc set triggers dc/system-app --from-image=amp-system:${THREESCALE_RELEASE} --containers=system-master,system-developer,system-provider --remove
+$ oc set triggers dc/system-app --from-image=amp-system:${THREESCALE_RELEASE}-oracle --containers=system-master,system-developer,system-provider
+```
+
+
+This triggers a redeployment of system-app DeploymentConfig. Wait until it is
+redeployed, its corresponding new pods are ready, and the old ones terminated.
+
+
+Update system-sidekiq DeploymentConfig's ImageChangeTrigger:
+```
+$ oc set triggers dc/system-sidekiq --from-image=amp-system:${THREESCALE_RELEASE} --containers=system-sidekiq,check-svc --remove
+$ oc set triggers dc/system-sidekiq --from-image=amp-system:${THREESCALE_RELEASE}-oracle --containers=system-sidekiq,check-svc
+```
+
+This triggers a redeployment of system-sidekiq DeploymentConfig. Wait until it is
+redeployed,  its corresponding new pods are ready, and the old ones terminated.
+
+Update system-sphinx DeploymentConfig's ImageChangeTriger:
+```
+$ oc set triggers dc/system-sphinx --from-image=amp-system:${THREESCALE_RELEASE} --containers=system-sphinx,system-master-svc --remove
+$ oc set triggers dc/system-sphinx --from-image=amp-system:${THREESCALE_RELEASE}-oracle --containers=system-sphinx,system-master-svc
+```
+
+This triggers a redeployment of system-sphinx DeploymentConfig. Wait until it is
+redeployed, its corresponding new pods are ready, and the old ones terminated.
+
+
 ## DATABASE_URL parameter specification
 
 The `DATABASE_URL` parameter **MUST** follow this format `oracle-enhanced://${user}:${password}@${host}:${port}/${database}`

--- a/amp/system-oracle/build.yml
+++ b/amp/system-oracle/build.yml
@@ -15,17 +15,22 @@ objects:
     output:
       to:
         kind: "ImageStreamTag"
-        name: "amp-system:latest"
-
+        name: "amp-system:${AMP_RELEASE}-oracle"
     strategy:
       type: Docker
       dockerStrategy:
         from:
-          kind: "ImageStreamTag"
-          name: "amp-system:${AMP_RELEASE}"
-
+          kind: "DockerImage"
+          name: "registry.redhat.io/3scale-amp2/system-rhel7:3scale${AMP_RELEASE}"
+        pullSecret:
+          name: "${PULLSECRET_NAME}"
+        forcePull: true
 
 parameters:
   - name: AMP_RELEASE
-    value: "2.8"
+    value: "2.9"
     description: 3scale AMP release version
+  - name: PULLSECRET_NAME
+    description: PullSecret is the name of a Secret that would be used for setting up the authentication for pulling the Docker images from the private Docker registries
+    value: "threescale-registry-auth"
+    required: true


### PR DESCRIPTION
Update system's Oracle image building method for 3scale 2.9

Important changes:
* Now image is taken directly from published system's registry.redhat.io
* Allow configurability of a pull-secret name to allow retrieval of
  registry.redhat.io image
* Set 3scale${AMP_RELEASE} as the tag of the system's registry.redhat.io
  image (AMP_RELEASE is a "2.9" by default and it is a floating tag)
* Now the image build output is stored in amp-system:${AMP_RELEASE}
  ImageStreamTag instead of on the latest tag
* Always force pull of the specified image
* Dockerfile now has a placeholder value in the FROM statement to
  clearly indicate it's arbitrary and the value doesn't really matter,
  as it will be replaced by the BuildConfig

Do not merge until 3scale 2.9 is GA