### PR TITLE
Fix overriden LD_LIBRARY_PATH

### DIFF
--- a/amp/system-oracle/Dockerfile
+++ b/amp/system-oracle/Dockerfile
@@ -7,7 +7,7 @@ COPY ./oracle-client-files/instantclient-basic*-linux.x64*.zip \
      ./oracle-client-files/instantclient-odbc-linux.x64*.zip \
      /opt/system/vendor/oracle/
 
-ENV LD_LIBRARY_PATH=/opt/oracle/instantclient/ \
+ENV LD_LIBRARY_PATH=/opt/oracle/instantclient/:$LD_LIBRARY_PATH \
     ORACLE_HOME=/opt/oracle/instantclient/ \
     DB=oracle \
     TZ=utc \


### PR DESCRIPTION
We just want to add the oracle libraries to that env var, not to completely replace it

Closes [THREESCALE-6455](https://issues.redhat.com/browse/THREESCALE-6455)