### PR TITLE
Soft link Oracle Instant clients on ppc64le

### DIFF
--- a/amp/system-oracle/Dockerfile
+++ b/amp/system-oracle/Dockerfile
@@ -13,7 +13,8 @@ ENV LD_LIBRARY_PATH=/opt/oracle/instantclient/:$LD_LIBRARY_PATH \
     TZ=utc \
     NLS_LANG=AMERICAN_AMERICA.UTF8
 
-RUN ./script/oracle/install-instantclient-packages.sh \
+RUN ln -s /opt/oracle/instantclient_19_3 /opt/oracle/instantclient_19_6 \
+ && ./script/oracle/install-instantclient-packages.sh \
  && source /opt/app-root/etc/scl_enable \
  && DB=oracle bundle install --local --deployment --jobs $(grep -c processor /proc/cpuinfo) --retry=5
 


### PR DESCRIPTION
Instant clients version  for ppc64le 19.3, whereas,
x86_64 have 19.6, this would cause issues while
rebuilding system image

Signed-off-by: Krishna Harsha Voora <krishvoor@in.ibm.com>