### PR TITLE
Jira SO-19: Remove non-groupified APIs in openshift/library templates

### DIFF
--- a/3scale-image-streams.yml
+++ b/3scale-image-streams.yml
@@ -1,9 +1,9 @@
 kind: ImageStreamList
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 metadata: {}
 items:
 - kind: ImageStream
-  apiVersion: v1
+  apiVersion: image.openshift.io/v1
   metadata:
     name: apicast-gateway
     annotations:

--- a/apicast-gateway/library/apicast.yml
+++ b/apicast-gateway/library/apicast.yml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: 3scale-gateway

--- a/apicast-gateway/library/apicast.yml
+++ b/apicast-gateway/library/apicast.yml
@@ -14,7 +14,7 @@ metadata:
     tags: api,gateway,3scale
 objects:
 
-- apiVersion: v1
+- apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
     name: "${APICAST_NAME}"


### PR DESCRIPTION
Non-groupified APIs were deprecated in OCP 4.7.

This PR only handles the imagestreams/Templates which are bundled in OpenShift. If any of the other imagestreams or templates are meant to still be used, they should also be similarly updated. A complete API list is available at https://docs.openshift.com/container-platform/4.10/rest_api/index.html 

Signed-off-by: Feny Mehta <fbm3307@gmail.com>