### PR TITLE
Remove command to set compatible parameter

### DIFF
--- a/amp/system-oracle/README.md
+++ b/amp/system-oracle/README.md
@@ -146,6 +146,5 @@ You need to configure your database properly in order to accomodate 3scale
 
 ```
 ALTER SYSTEM SET max_string_size=extended SCOPE=SPFILE;
-ALTER SYSTEM SET compatible='12.2.0.1' SCOPE=SPFILE;
 ```
 


### PR DESCRIPTION
As discussed in https://issues.redhat.com/browse/THREESCALE-6613 this is no longer needed and was already removed from our official documentation, so we need to ensure the README which gets downloaded as part of the steps to integrate OracleDB with 3scale are aligned.

Partially fixes THREESCALE-6613