### PR TITLE
Remove statement about Oracle SYSTEM password

### DIFF
--- a/amp/system-oracle/README.md
+++ b/amp/system-oracle/README.md
@@ -20,7 +20,6 @@ Example:
 ### Oracle Database user SYSTEM password
 
 We **need** the Oracle Database user `SYSTEM` password.
-It will create the user and grant the appropriate roles and rights to the user connecting to the database.
 
 
 ## Instructions


### PR DESCRIPTION
This removes the inaccurate statement about why the SYSTEM password is required.

Fixes [#THREESCALE-8738](https://issues.redhat.com/browse/THREESCALE-8738)