### PR TITLE
Move oracle ruby gems from generic product container image to oracle-specific one

### DIFF
--- a/amp/system-oracle/Dockerfile
+++ b/amp/system-oracle/Dockerfile
@@ -13,6 +13,19 @@ ENV LD_LIBRARY_PATH=/opt/oracle/instantclient/:$LD_LIBRARY_PATH \
     TZ=utc \
     NLS_LANG=AMERICAN_AMERICA.UTF8
 
+WORKDIR /opt/system
+
+RUN source /opt/app-root/etc/scl_enable \
+    && printf "source 'https://rubygems.org'\ngem 'activerecord-oracle_enhanced-adapter'\ngem 'ruby-oci8'\n" > Gemfile.oracle \
+    && cp Gemfile.lock Gemfile.oracle.lock \
+    && mv .bundle .bundle.bak && mkdir .bundle \
+    && bundle config set --local no_install true \
+    && bundle config set --local cache_all true \
+    && bundle package --gemfile=Gemfile.oracle --no-install --all \
+    && rm -rf Gemfile.oracle* .bundle \
+    && mv .bundle.bak .bundle
+
+
 RUN ./script/oracle/install-instantclient-packages.sh \
  && source /opt/app-root/etc/scl_enable \
  && DB=oracle bundle install --local --deployment --jobs $(grep -c processor /proc/cpuinfo) --retry=5

--- a/amp/system-oracle/Dockerfile
+++ b/amp/system-oracle/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/3scale-amp2/system-rhel7:3scale2.11
+FROM registry.redhat.io/3scale-amp2/system-rhel7:3scale2.13
 
 USER root
 

--- a/amp/system-oracle/Dockerfile
+++ b/amp/system-oracle/Dockerfile
@@ -21,6 +21,8 @@ RUN source /opt/app-root/etc/scl_enable \
     && mv .bundle .bundle.bak && mkdir .bundle \
     && bundle config set --local no_install true \
     && bundle config set --local cache_all true \
+    && bundle config unset mirror.http://rubygems.org/ \
+    && bundle config unset mirror.https://rubygems.org/ \
     && bundle package --gemfile=Gemfile.oracle --no-install --all \
     && rm -rf Gemfile.oracle* .bundle \
     && mv .bundle.bak .bundle


### PR DESCRIPTION
Move oracle ruby gems from generic product container image to oracle-specific one

No need to have them in the product container image anyway, since we're building a new image here and the libraries can be installed in this container image.
